### PR TITLE
Update developer_setup.md

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -117,6 +117,7 @@
 
   ```bash
   brew install git
+  brew install pkg-config
   brew install memcached
   brew install postgresql
   brew install cmake


### PR DESCRIPTION
Rugged requires `cmake` and `pkg-config`. Ran into build errors without this one yesterday on Mac...but adding pkg-config enabled setup script to work.

See install notes for rugged:
https://github.com/libgit2/rugged#install